### PR TITLE
fix ユニットテストにtearDownClass()メソッドを追加した

### DIFF
--- a/api/v1/authentication/tests/test_login_apiview.py
+++ b/api/v1/authentication/tests/test_login_apiview.py
@@ -78,3 +78,9 @@ class LoginAPIViewTest(TestCase):
                 expected_json_dict = {'username': ['この項目は必須です。']}
 
             self.assertJSONEqual(response.content, expected_json_dict)
+
+    @classmethod
+    def tearDownClass(cls):
+        user = User.objects.get(username='login_apiview')
+        user.delete()
+        return super().tearDownClass()

--- a/api/v1/authentication/tests/test_login_serializer.py
+++ b/api/v1/authentication/tests/test_login_serializer.py
@@ -54,3 +54,9 @@ class LoginSerializerTest(TestCase):
         for input_data in input_data_list:
             serializer = LoginSerializer(data=input_data)
             self.assertFalse(serializer.is_valid())
+
+    @classmethod
+    def tearDownClass(cls):
+        user = User.objects.get(username='login_serializer')
+        user.delete()
+        return super().tearDownClass()

--- a/api/v1/authentication/tests/test_logout_apiview.py
+++ b/api/v1/authentication/tests/test_logout_apiview.py
@@ -23,3 +23,9 @@ class LogoutAPIViewTest(TestCase):
         # JSONレスポンスの確認
         expected_json_dict = {'detail': ['ログアウトに成功しました']}
         self.assertJSONEqual(response.content, expected_json_dict)
+
+    @classmethod
+    def tearDownClass(cls):
+        user = User.objects.get(username='logout_apiview')
+        user.delete()
+        return super().tearDownClass()


### PR DESCRIPTION
ユニットテストでsetUpClass()メソッドでモデルを作成している場合にteadDownClass()メソッドで作成したモデル