### PR TITLE
ユーザの詳細取得,更新,削除を行う機能とパスワードを変更する機能を追加した

### DIFF
--- a/api/v1/users/permissions.py
+++ b/api/v1/users/permissions.py
@@ -1,0 +1,20 @@
+from rest_framework.permissions import SAFE_METHODS, BasePermission
+
+
+class IsSelfOrReadOnly(BasePermission):
+    """
+    GET, HEAD, OPTIONSメソッドの場合は全てのユーザにアクセスを許可し,それ以外のメソッドの
+    場合は認証されており,かつアクセスしているユーザとURLに含まれるユーザが同じである必要がある
+    """
+
+    def __init__(self, username=''):
+        super().__init__()
+        self.username = username
+
+    def has_permission(self, request, view):
+        # viewからlookup_fieldを介して取得したユーザ名(obj)とrequest.userを比較する
+        return bool(
+            request.method in SAFE_METHODS or
+            request.user.is_authenticated and
+            request.user.username == self.username
+        )

--- a/api/v1/users/serializers.py
+++ b/api/v1/users/serializers.py
@@ -1,4 +1,5 @@
 from django.contrib.auth import get_user_model
+from django.core.exceptions import ValidationError
 from rest_framework import serializers
 
 User = get_user_model()
@@ -16,3 +17,23 @@ class UserSerializer(serializers.ModelSerializer):
                 'read_only': True,
             },
         }
+
+
+class UserPrivateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ['username', 'email', 'icon']
+
+    def validate_icon(self, value):
+        if not value:
+            raise ValidationError('画像ファイルをアップロードしてください')
+
+        try:
+            if value.image.width > 512 or value.image.height > 512:
+                raise ValidationError('縦幅・横幅が512pxより大きい画像はアップロードする事が出来ません')
+        except AttributeError:
+            # ログインユーザの現在のアイコンと異なるファイルにも関わらず画像データが無い場合はエラーとする
+            if self.user.icon != value:
+                raise ValidationError('画像ファイルをアップロードしてください')
+
+        return value

--- a/api/v1/users/serializers.py
+++ b/api/v1/users/serializers.py
@@ -1,6 +1,9 @@
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
+from django.contrib.auth.models import AnonymousUser
+from django.contrib.auth.password_validation import validate_password
 from rest_framework import serializers
+from rest_framework.fields import empty
 
 User = get_user_model()
 
@@ -37,3 +40,43 @@ class UserPrivateSerializer(serializers.ModelSerializer):
                 raise ValidationError('画像ファイルをアップロードしてください')
 
         return value
+
+
+class PasswordChangeSerializer(serializers.ModelSerializer):
+    old_password = serializers.CharField(write_only=True, required=True)
+    password = serializers.CharField(write_only=True, required=True,
+                                     validators=[validate_password])
+    password2 = serializers.CharField(write_only=True, required=True)
+
+    class Meta:
+        model = User
+        fields = ('old_password', 'password', 'password2')
+
+    def __init__(self, instance=None, data=empty, **kwargs):
+        self.instance = instance
+        if data is not empty:
+            self.initial_data = data
+        self.partial = kwargs.pop('partial', False)
+        self._context = kwargs.pop('context', {})
+        self.user = kwargs.pop('user', AnonymousUser)
+        kwargs.pop('many', None)
+        super().__init__(instance=instance, data=data, **kwargs)
+
+    def validate_old_password(self, value):
+        if not self.user.check_password(value):
+            raise serializers.ValidationError(
+                {'old_password': ['入力されたパスワードが間違っています。']}
+            )
+        return value
+
+    def validate(self, value):
+        if value['password'] != value['password2']:
+            raise serializers.ValidationError(
+                {'password': ['入力されたパスワードが一致しません。']}
+            )
+        return value
+
+    def update(self, instance, validated_data):
+        instance.set_password(validated_data['password'])
+        instance.save()
+        return instance

--- a/api/v1/users/tests/test_password_changeapiview.py
+++ b/api/v1/users/tests/test_password_changeapiview.py
@@ -1,0 +1,95 @@
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework.test import APITestCase, APIClient
+
+User = get_user_model()
+
+
+class PasswordChangeAPIViewTest(APITestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        User.objects.create_user(username='password_changeapiview',
+                                 email='password_changeapiview@test.com',
+                                 password='testpassw0rd123')
+
+    def test_1_success_update_password(self):
+        # 適切なパラメータによってユーザのパスワードを更新する事が出来る
+        params = {
+            'old_password': 'testpassw0rd123',
+            'password': 'updatetestpassw0rd123',
+            'password2': 'updatetestpassw0rd123',
+        }
+
+        user = User.objects.get(username='password_changeapiview')
+        client = APIClient()
+        client.force_login(user)
+        response = client.patch(reverse('api:v1:users:change_password',
+                                        kwargs={'username': 'password_changeapiview'}),
+                                params,
+                                format='json')
+        # HTTPレスポンスステータスコードの検証
+        self.assertEqual(response.status_code, 200)
+        # パスワードが更新されたか検証
+        updated_user = User.objects.get(username='password_changeapiview')
+        self.assertTrue(updated_user.check_password('updatetestpassw0rd123'))
+
+    def test_2_fail_update_password(self):
+        # 正しいパラメータであってもログインしていなければユーザのパスワードを更新する事が出来ない
+        params = {
+            'old_password': 'testpassw0rd123',
+            'password': 'updatetestpassw0rd123',
+            'password2': 'updatetestpassw0rd123',
+        }
+
+        client = APIClient()
+        response = client.patch(reverse('api:v1:users:change_password',
+                                        kwargs={'username': 'password_changeapiview'}),
+                                params,
+                                format='json')
+        # HTTPレスポンスステータスコードの検証
+        self.assertEqual(response.status_code, 403)
+
+    def test_3_fail_uppdate_password(self):
+        # 誤ったパラメータまたは欠けたパラメータが存在する場合はユーザのパスワードを更新する事は出来ない
+        wrong_params_list = [
+            {
+                'password': 'updatetestpassw0rd123',
+                'password2': 'updatetestpassw0rd123',
+            },
+            {
+                'old_password': 'testpassw0rd123',
+                'password2': 'updatetestpassw0rd123',
+            },
+            {
+                'old_password': 'testpassw0rd123',
+                'password': 'updatetestpassw0rd123',
+            },
+            {
+                'old_password': 'wrongpassword',
+                'password': 'updatetestpassw0rd123',
+                'password2': 'updatetestpassw0rd123',
+            },
+            {
+                'old_password': 'testpassw0rd123',
+                'password': 'wrongpassword',
+                'password2': 'updatetestpassw0rd123',
+            },
+            {
+                'old_password': 'testpassw0rd123',
+                'password': 'updatetestpassw0rd123',
+                'password2': 'wrongpassword',
+            },
+        ]
+
+        user = User.objects.get(username='password_changeapiview')
+        client = APIClient()
+        client.force_login(user)
+
+        for wrong_params in wrong_params_list:
+            response = client.patch(reverse('api:v1:users:change_password',
+                                            kwargs={'username': 'password_changeapiview'}),
+                                    wrong_params,
+                                    format='json')
+            # HTTPレスポンスステータスコードの検証
+            self.assertEqual(response.status_code, 400)

--- a/api/v1/users/tests/test_password_changeserializer.py
+++ b/api/v1/users/tests/test_password_changeserializer.py
@@ -1,0 +1,75 @@
+from django.contrib.auth import get_user_model
+from rest_framework.test import APITestCase
+
+from ..serializers import PasswordChangeSerializer
+
+User = get_user_model()
+
+
+class PasswordChangeSerializerTest(APITestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        User.objects.create_user(
+            username='password_changeserializer',
+            email='password_changeserializer@test.com',
+            password='testpassw0rd123',)
+
+    def test_1_valid_and_success_update(self):
+        # 正しい入力値は妥当であり,それによってパスワードを更新する事が出来る
+        user = User.objects.get(username='password_changeserializer')
+        params = {
+            'old_password': 'testpassw0rd123',
+            'password': 'updatedtestpassw0rd123',
+            'password2': 'updatedtestpassw0rd123'
+        }
+
+        serializer = PasswordChangeSerializer(instance=user,
+                                              data=params,
+                                              user=user)
+        # バリデーション結果の検証
+        self.assertTrue(serializer.is_valid())
+        serializer.update(user, serializer.validated_data)
+        # パスワードが更新されたか検証
+        self.assertTrue(user.check_password('updatedtestpassw0rd123'))
+
+    def test_2_invalid(self):
+        # 誤った入力値または欠けた状態は妥当ではない
+        user = User.objects.get(username='password_changeserializer')
+        invalid_params_list = [
+            {
+                'password': 'updatedtestpassw0rd123',
+                'password2': 'updatedtestpassw0rd123'
+            },
+            {
+                'old_password': 'wrongpass',
+                'password2': 'updatedtestpassw0rd123'
+            },
+            {
+                'old_password': 'wrongpass',
+                'password': 'updatedtestpassw0rd123',
+            },
+            {
+                'old_password': 'wrongpass',
+                'password': 'updatedtestpassw0rd123',
+                'password2': 'updatedtestpassw0rd123'
+            },
+            {
+                'old_password': 'testpassw0rd123',
+                'password': 'wrongpass',
+                'password2': 'updatedtestpassw0rd123'
+            },
+
+            {
+                'old_password': 'testpassw0rd123',
+                'password': 'updatedtestpassw0rd123',
+                'password2': 'wrongpass'
+            },
+        ]
+
+        for invalid_params in invalid_params_list:
+            serializer = PasswordChangeSerializer(instance=user,
+                                                  data=invalid_params,
+                                                  user=user)
+            # バリデーション結果の検証
+            self.assertFalse(serializer.is_valid())

--- a/api/v1/users/tests/test_user_listapiview.py
+++ b/api/v1/users/tests/test_user_listapiview.py
@@ -1,13 +1,13 @@
 from django.contrib.auth import get_user_model
-from django.test import TestCase
 from django.urls import reverse
 from urllib.parse import urlencode
 from json import loads as json_loads
+from rest_framework.test import APITestCase, APIClient
 
 User = get_user_model()
 
 
-class UserListAPIViewTest(TestCase):
+class UserListAPIViewTest(APITestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -22,7 +22,8 @@ class UserListAPIViewTest(TestCase):
 
     def test_success_access_and_get_users(self):
         # APIViewに対してアクセスする事と10件の情報を取得する事が出来る
-        response = self.client.get(reverse('api:v1:users:list'))
+        client = APIClient()
+        response = client.get(reverse('api:v1:users:list'))
 
         # ステータスコードの確認
         self.assertEqual(response.status_code, 200)
@@ -32,9 +33,10 @@ class UserListAPIViewTest(TestCase):
 
     def test_success_access_max_page(self):
         # ページネーションが正常に機能し,最後のページの場合next=nullとなっている
-        response = self.client.get(''.join([reverse('api:v1:users:list'),
-                                           '?',
-                                            urlencode(dict(page='3'))]))
+        client = APIClient()
+        response = client.get(''.join([reverse('api:v1:users:list'),
+                                       '?',
+                                       urlencode(dict(page='3'))]))
 
         # ステータスコードの確認
         self.assertEqual(response.status_code, 200)
@@ -45,9 +47,10 @@ class UserListAPIViewTest(TestCase):
     def test_success_get_only_satisfy_requirment(self):
         # qパラメータで指定した条件に合致する情報のみ取得する事可能で,
         # ページネーションも正常に機能している
-        response = self.client.get(''.join([reverse('api:v1:users:list'),
-                                           '?',
-                                            urlencode(dict(q='user_listapiview_A'))]))
+        client = APIClient()
+        response = client.get(''.join([reverse('api:v1:users:list'),
+                                       '?',
+                                       urlencode(dict(q='user_listapiview_A'))]))
 
         # ステータスコードの確認
         self.assertEqual(response.status_code, 200)
@@ -57,9 +60,10 @@ class UserListAPIViewTest(TestCase):
 
     def test_fail_access_over_page(self):
         # ページネーションが正常に機能し,存在しないページにアクセスすると404が返ってくる
-        response = self.client.get(''.join([reverse('api:v1:users:list'),
-                                           '?',
-                                            urlencode(dict(page='4'))]))
+        client = APIClient()
+        response = client.get(''.join([reverse('api:v1:users:list'),
+                                       '?',
+                                       urlencode(dict(page='4'))]))
 
         # ステータスコードの確認
         self.assertEqual(response.status_code, 404)
@@ -69,9 +73,10 @@ class UserListAPIViewTest(TestCase):
 
     def test_fail_get_no_satisfy_requirment(self):
         # 条件に合致するデータが無い時,何も取得できない
-        response = self.client.get(''.join([reverse('api:v1:users:list'),
-                                           '?',
-                                            urlencode(dict(q='user_listapiview_C'))]))
+        client = APIClient()
+        response = client.get(''.join([reverse('api:v1:users:list'),
+                                       '?',
+                                       urlencode(dict(q='user_listapiview_C'))]))
 
         # ステータスコードの確認
         self.assertEqual(response.status_code, 200)

--- a/api/v1/users/tests/test_user_listapiview.py
+++ b/api/v1/users/tests/test_user_listapiview.py
@@ -21,7 +21,7 @@ class UserListAPIViewTest(TestCase):
                                      password='testpassw0rd123')
 
     def test_success_access_and_get_users(self):
-        # エンドポイントに対してアクセスする事と10件の情報を取得する事が出来る
+        # APIViewに対してアクセスする事と10件の情報を取得する事が出来る
         response = self.client.get(reverse('api:v1:users:list'))
 
         # ステータスコードの確認

--- a/api/v1/users/tests/test_user_privateserializer.py
+++ b/api/v1/users/tests/test_user_privateserializer.py
@@ -1,0 +1,147 @@
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
+from io import BytesIO
+from PIL import Image
+from rest_framework.test import APITestCase
+from shutil import rmtree
+from tempfile import mkdtemp
+
+
+from ..serializers import UserPrivateSerializer
+
+User = get_user_model()
+
+
+class UserSerializerTest(APITestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # テストで画像を格納するのに利用する一時的なディレクトリの作成
+        settings.MEDIA_ROOT = mkdtemp()
+        User.objects.create_user(
+            username='user_privateserializer',
+            email='user_privateserializer@test.com',
+            password='testpassw0rd123',)
+
+        User.objects.create_user(
+            username='user_privateserializerA',
+            email='user_privateserializerA@test.com',
+            password='testpassw0rd123',)
+
+    def test_1_success_retrive(self):
+        # 期待したユーザのデータを取得する事が出来る
+        user = User.objects.get(username='user_privateserializer')
+        serializer = UserPrivateSerializer(instance=user)
+        expected_json = {'username': 'user_privateserializer',
+                         'email': 'user_privateserializer@test.com',
+                         'icon': '/images/default.png'}
+        self.assertEqual(serializer.data, expected_json)
+
+    def test_2_valid_and_success_update(self):
+        # 適切な入力値は妥当でありユーザ情報(ユーザ名,メアド,アイコン)を更新する事が出来る
+        image = BytesIO()
+        Image.new('RGB', (512, 512)).save(image, 'PNG')
+        image.seek(0)
+
+        params = {
+            'username': 'user_privateserializer2',
+            'email': 'user_privateserializer2@test.com',
+            'icon': SimpleUploadedFile('user_privateserializer2.png',
+                                       image.getvalue())
+        }
+
+        user = User.objects.get(username='user_privateserializer')
+        serializer = UserPrivateSerializer(instance=user, data=params)
+
+        # バリデーション結果の検証
+        self.assertTrue(serializer.is_valid())
+        serializer.save()
+        # 更新が行われたかの検証
+        updated_user = User.objects.get(username='user_privateserializer2')
+        self.assertEqual(updated_user.email, 'user_privateserializer2@test.com')
+        self.assertEqual(updated_user.icon, 'images/user_privateserializer2.png')
+
+    def test_3_success_update_partial(self):
+        # シリアライザを定義する時にpartial=Trueとする事で部分的に更新する事が出来る
+        image = BytesIO()
+        Image.new('RGB', (512, 512)).save(image, 'PNG')
+        image.seek(0)
+
+        param_list = [
+            {
+                'username': 'user_privateserializer3',
+            },
+            {
+                'email': 'user_privateserializer3@test.com',
+            },
+            {
+                'icon': SimpleUploadedFile('user_privateserializer3.png',
+                                           image.getvalue())
+            }
+        ]
+
+        user = User.objects.get(username='user_privateserializer')
+        for param in param_list:
+            serializer = UserPrivateSerializer(instance=user,
+                                               data=param,
+                                               partial=True)
+            # バリデーション結果の検証
+            self.assertTrue(serializer.is_valid())
+            serializer.save()
+        # 最終的な結果の比較
+        updated_user = User.objects.get(username='user_privateserializer3')
+        self.assertEqual(updated_user.email, 'user_privateserializer3@test.com')
+        self.assertEqual(updated_user.icon, 'images/user_privateserializer3.png')
+
+    def test_4_invalid(self):
+        # 重複した値または適切でない入力値は妥当ではない
+        valid_image = BytesIO()
+        Image.new('RGB', (512, 512)).save(valid_image, 'PNG')
+        valid_image.seek(0)
+
+        invalid_image = BytesIO()
+        Image.new('RGB', (512, 513)).save(invalid_image, 'PNG')
+        invalid_image.seek(0)
+
+        invalid_image2 = BytesIO()
+        Image.new('RGB', (513, 512)).save(invalid_image2, 'PNG')
+        invalid_image2.seek(0)
+
+        invalid_params_list = [
+            {
+                'username': 'user_privateserializerA',
+                'email': 'user_privateserializer2@test.com',
+                'icon': SimpleUploadedFile('user_privateserializer2.png',
+                                           valid_image.getvalue())
+            },
+            {
+                'username': 'user_updateserialize2',
+                'email': 'user_privateserializerA@test.com',
+                'icon': SimpleUploadedFile('user_privateserializer2.png',
+                                           valid_image.getvalue())
+            },
+            {
+                'username': 'user_privateserializer2',
+                'email': 'user_privateserializer2@test.com',
+                'icon': SimpleUploadedFile('user_privateserializer2.png',
+                                           invalid_image.getvalue())
+            },
+            {
+                'username': 'user_privateserializer2',
+                'email': 'user_privateserializer2@test.com',
+                'icon': SimpleUploadedFile('user_privateserializer2.png',
+                                           invalid_image2.getvalue())
+            },
+        ]
+
+        user = User.objects.get(username='user_privateserializer')
+        for invalid_params in invalid_params_list:
+            serializer = UserPrivateSerializer(instance=user, data=invalid_params)
+            self.assertFalse(serializer.is_valid())
+
+    @classmethod
+    def tearDownClass(cls):
+        # テストで作成した画像ファイルを格納しているディレクトリを削除する
+        rmtree(settings.MEDIA_ROOT, ignore_errors=True)
+        super().tearDownClass()

--- a/api/v1/users/tests/test_user_rudapiview.py
+++ b/api/v1/users/tests/test_user_rudapiview.py
@@ -1,0 +1,83 @@
+from base64 import b64encode
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+from io import BytesIO
+from PIL import Image
+from rest_framework.test import APITestCase, APIClient
+from shutil import rmtree
+from tempfile import mkdtemp
+
+User = get_user_model()
+
+
+class UserRetrieveUpdateDestroyAPIViewTest(APITestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        settings.MEDIA_ROOT = mkdtemp()
+        User.objects.create_user(username='user_rudapiview',
+                                 email='user_rudapiview@test.com',
+                                 password='testpassw0rd123')
+
+        User.objects.create_user(username='user_rudapiviewA',
+                                 email='user_rudapiviewA@test.com',
+                                 password='testpassw0rd123')
+
+    def test_1_success_access_and_retrive(self):
+        # APIViewに対してアクセスする事と指定したユーザの情報を取得する事が出来る
+        client = APIClient()
+        response = client.get(reverse('api:v1:users:detail',
+                                      kwargs={'username': 'user_rudapiview'}))
+
+        # ステータスコードの確認
+        self.assertEqual(response.status_code, 200)
+        # JSONレスポンスの確認
+        expected_json = {"username": "user_rudapiview",
+                         "icon": "http://testserver/images/default.png"}
+        self.assertJSONEqual(response.content, expected_json)
+
+    def test_2_fail_access(self):
+        # 存在しないユーザ名を指定してAPIViewに対してアクセスすると404が返される
+        client = APIClient()
+        response = client.get(reverse('api:v1:users:detail',
+                                      kwargs={'username': 'fail_access'}))
+
+        # ステータスコードの確認
+        self.assertEqual(response.status_code, 404)
+        # JSONレスポンスの確認
+        expected_json = {"detail": "見つかりませんでした。"}
+        self.assertJSONEqual(response.content, expected_json)
+
+    def test_3_success_update(self):
+        # APIViewに対して適切な入力値によって更新する事が出来る
+        image = BytesIO()
+        Image.new('RGB', (512, 512)).save(image, 'PNG')
+        image.seek(0)
+        encode_image = b64encode(image.getvalue())
+
+        params = {
+            'username': 'user_rudapiview2',
+            'email': 'user_rudapiviewA@test.com',
+            'icon': SimpleUploadedFile('user_rudapiview2.png',
+                                       encode_image,
+                                       content_type='multipart/form-data')
+        }
+
+        user = User.objects.get(username='user_rudapiview')
+
+    def test_4_success_delete(self):
+        # APIViewに対してログインしているユーザと同じユーザ名のユーザを削除する事が出来る
+        user = User.objects.get(username='user_rudapiview')
+        client = APIClient()
+        client.force_login(user)
+        response = client.delete(reverse('api:v1:users:detail',
+                                         kwargs={'username': 'user_rudapiview'}))
+        self.assertEqual(response.status_code, 204)
+
+    @classmethod
+    def tearDownClass(cls):
+        # テストで作成した画像ファイルを格納しているディレクトリを削除する
+        rmtree(settings.MEDIA_ROOT, ignore_errors=True)
+        super().tearDownClass()

--- a/api/v1/users/tests/test_user_serializer.py
+++ b/api/v1/users/tests/test_user_serializer.py
@@ -18,7 +18,7 @@ class UserSerializerTest(TestCase):
                 password='testpassw0rd123',
                 icon='user_serializer_{}.png'.format(i))
 
-    def test_valid(self):
+    def test_success_get_list(self):
         users = User.objects.all()
         serializer = UserSerializer(instance=users, many=True)
         # 予想したJSON形式の文字列をシリアライザから取得できる

--- a/api/v1/users/tests/test_user_serializer.py
+++ b/api/v1/users/tests/test_user_serializer.py
@@ -1,13 +1,13 @@
 from django.contrib.auth import get_user_model
-from django.test import TestCase
 from json import dumps as json_dump
+from rest_framework.test import APITestCase
 
 from ..serializers import UserSerializer
 
 User = get_user_model()
 
 
-class UserSerializerTest(TestCase):
+class UserSerializerTest(APITestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/api/v1/users/urls.py
+++ b/api/v1/users/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
 
-from .views import UserListAPIView
+from .views import UserListAPIView, UserRetrieveUpdateDestroyAPIView
 
 app_name = 'users'
 
 urlpatterns = [
     path('', UserListAPIView.as_view(), name='list'),
+    path('<str:username>/', UserRetrieveUpdateDestroyAPIView.as_view(), name='detail'),
 ]

--- a/api/v1/users/urls.py
+++ b/api/v1/users/urls.py
@@ -1,10 +1,13 @@
 from django.urls import path
 
-from .views import UserListAPIView, UserRetrieveUpdateDestroyAPIView
+from .views import UserListAPIView, UserRetrieveUpdateDestroyAPIView, PasswordChangeAPIView
 
 app_name = 'users'
 
 urlpatterns = [
     path('', UserListAPIView.as_view(), name='list'),
-    path('<str:username>/', UserRetrieveUpdateDestroyAPIView.as_view(), name='detail'),
+    path('<str:username>/', UserRetrieveUpdateDestroyAPIView.as_view(),
+         name='detail'),
+    path('<str:username>/change-password/', PasswordChangeAPIView.as_view(),
+         name='change_password'),
 ]

--- a/api/v1/users/views.py
+++ b/api/v1/users/views.py
@@ -1,9 +1,10 @@
 from django.contrib.auth import get_user_model
 from django_filters import rest_framework as filters
-from rest_framework.generics import ListAPIView
+from rest_framework.generics import ListAPIView, RetrieveUpdateDestroyAPIView
 from rest_framework.permissions import AllowAny
 
-from .serializers import UserSerializer
+from .permissions import IsSelfOrReadOnly
+from .serializers import UserSerializer, UserPrivateSerializer
 
 User = get_user_model()
 
@@ -21,3 +22,28 @@ class UserListAPIView(ListAPIView):
     serializer_class = UserSerializer
     permission_classes = [AllowAny]
     filter_class = UserListFilter
+
+
+class UserRetrieveUpdateDestroyAPIView(RetrieveUpdateDestroyAPIView):
+    """
+    指定したユーザの詳細情報の取得,情報の更新,削除を行うAPIView
+    """
+    lookup_field = 'username'
+    queryset = User.objects.all().order_by('date_joined')
+    serializer_class = UserSerializer
+    permission_classes = [IsSelfOrReadOnly]
+
+    def get_serializer_class(self):
+        # アクセスしてきたユーザのユーザ名と情報を取得するユーザ名が一致する場合はシリアライザを切り替える
+        lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
+        username_in_url = self.kwargs[lookup_url_kwarg]
+
+        if self.request.user.username == username_in_url:
+            return UserPrivateSerializer
+        return self.serializer_class
+
+    def get_permissions(self):
+        # パーミッションクラスにアクセスしたURLに含まれるユーザ名を渡す
+        lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
+        return [permission(username=(self.kwargs[lookup_url_kwarg]))
+                for permission in self.permission_classes]


### PR DESCRIPTION
# 追加点

## /users/<str:username>

- ユーザの更新を行うためのUserPrivateSerializerを作成し,検証した
- ユーザの詳細取得,更新,削除を行うUserRetrieveUpdateDestroyAPIViewを作成し,検証した

## /users/<str:username>/change-password

- ユーザのパスワードを更新するためのPasswordChangeSerializerとPasswordChangeAPIViewを作成し,検証した