### PR TITLE
add カードの詳細取得,部分更新,削除を行うためのAPIViewとシリアライザの追加

### DIFF
--- a/api/v1/cards/tests/test_card_retriveserializer.py
+++ b/api/v1/cards/tests/test_card_retriveserializer.py
@@ -25,7 +25,7 @@ class CardRetrieveSerializerTest(APITestCase):
         )
 
     def test_1_success_retrive(self):
-        # シリアライザを介して指定したカードオブジェクトを取得する事が出来る
+        # シリアライザを介して指定したシリアライズされたカードのデータを取得する事が出来る
         card = Card.objects.get(word='card_retrieve_serializer')
         serializer = CardRetrieveSerializer(instance=card)
         # 取得したデータの内容を比較する (項目名によって検査する)

--- a/api/v1/wordbooks/permissions.py
+++ b/api/v1/wordbooks/permissions.py
@@ -1,0 +1,25 @@
+from rest_framework.permissions import BasePermission
+
+
+class IsNotAuthorReadPublicOnly(BasePermission):
+    def __init__(self, wordbook=None):
+        super().__init__()
+        self.wordbook = wordbook
+
+    def has_permission(self, request, view):
+        if not self.wordbook.is_hidden:
+            # 公開単語帳に対して作者の場合は全ての操作を許可
+            if request.user.id == self.wordbook.author.id:
+                return bool(
+                    True
+                )
+
+            # 公開単語帳に対して作者でない場合はGETのみ許可
+            return bool(
+                request.method == 'GET'
+            )
+
+        # 非公開他単語帳に対してはGET, PATCH, DELETE全ての処理が作者のみに許可される
+        return bool(
+            request.user.id == self.wordbook.author.id
+        )

--- a/api/v1/wordbooks/serializers.py
+++ b/api/v1/wordbooks/serializers.py
@@ -1,6 +1,11 @@
+from django.contrib.auth import get_user_model
 from rest_framework import serializers
 from rest_framework.exceptions import ErrorDetail, ValidationError
+
 from .models import Wordbook
+from ..cards.models import Card
+
+User = get_user_model()
 
 
 class WordbookSerializer(serializers.ModelSerializer):
@@ -15,6 +20,82 @@ class WordbookSerializer(serializers.ModelSerializer):
                 'read_only': True
             }
         }
+
+
+class WordbookRetrieveSerializer(serializers.ModelSerializer):
+    author_name = serializers.SerializerMethodField('get_author_name')
+
+    class Meta:
+        model = Wordbook
+        fields = ['id', 'wordbook_name', 'create_date', 'is_hidden',
+                  'author_name']
+        extra_kwargs = {
+            'id': {
+                'read_only': True
+            },
+            'wordbook_name': {
+                'read_only': True
+            },
+            'create_date': {
+                'read_only': True
+            },
+            'is_hidden': {
+                'read_only': True
+            },
+            'author_name': {
+                'read_only': True
+            },
+        }
+
+    def get_author_name(self, wordbook):
+        author_id = wordbook.author.id
+        author = User.objects.get(id=author_id)
+        return author.username
+
+
+class WordbookUpdateSerializer(serializers.Serializer):
+    wordbook_name = serializers.CharField(max_length=100, write_only=True)
+    is_hidden = serializers.BooleanField(write_only=True)
+    add_cards = serializers.ListField(
+        child=serializers.UUIDField(),
+        write_only=True
+    )
+    delete_cards = serializers.ListField(
+        child=serializers.UUIDField(),
+        write_only=True
+    )
+
+    def add_cards_to_wordbook(self, instance, add_card_id_list):
+        # 逆参照を利用して単語帳にカードを追加
+        add_cards = Card.objects.filter(id__in=add_card_id_list).all()
+        if len(add_cards) != 0:
+            for card in add_cards:
+                instance.cards.add(card)
+                instance.save()
+
+    def delete_cards_from_wordbook(self, instance, delete_card_id_list):
+        # 逆参照を利用して単語帳からカードを削除
+        delete_cards = Card.objects.filter(id__in=delete_card_id_list).all()
+        if len(delete_cards) != 0:
+            for card in delete_cards:
+                instance.cards.remove(card)
+                instance.save()
+
+    def update(self, instance, validated_data):
+        # 各項目の値の更新を行う
+        for key in validated_data.keys():
+            if key == 'add_cards':
+                self.add_cards_to_wordbook(instance, validated_data['add_cards'])
+                continue
+            elif key == 'delete_cards':
+                self.delete_cards_from_wordbook(instance, validated_data['delete_cards'])
+                continue
+            else:
+                setattr(instance, key, validated_data[key])
+
+        # 変更を反映してからインスタンスを返す
+        instance.save()
+        return instance
 
 
 class WordbookCreateSerializer(serializers.ModelSerializer):

--- a/api/v1/wordbooks/tests/test_wordbook_rdpuapiview.py
+++ b/api/v1/wordbooks/tests/test_wordbook_rdpuapiview.py
@@ -1,0 +1,305 @@
+from django.contrib.auth import get_user_model
+from django.core.exceptions import ObjectDoesNotExist
+from django.urls import reverse
+from json import loads as json_loads
+from rest_framework.test import APITestCase, APIClient
+
+from ..models import Wordbook
+from ...cards.models import Card
+
+User = get_user_model()
+
+
+class WordbookRetrieveDeletePartialUpdateAPIViewTestCase(APITestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        user = User.objects.create(
+            username='wordbook_rdpuapiview',
+            email='wordbook_rdpuapiview@test.com',
+            password='testpassw0rd123',
+        )
+        user.save()
+
+        user2 = User.objects.create(
+            username='wordbook_rdpuapiview2',
+            email='wordbook_rdpuapiview2@test.com',
+            password='testpassw0rd123',
+        )
+        user2.save()
+
+        card = Card(
+            word='wordbook_rdpuapiview',
+            answer='wordbook_rdpuapiview',
+            author=user,
+        )
+        card.save()
+
+        card2 = Card(
+            word='wordbook_rdpuapiview2',
+            answer='wordbook_rdpuapiview2',
+            author=user,
+        )
+        card2.save()
+
+        wordbook = Wordbook(
+            wordbook_name='wordbook_rdpuapiview_public',
+            is_hidden=False,
+            author=user,
+        )
+        wordbook.cards.add(card)
+        wordbook.save()
+
+        Wordbook.objects.create(
+            wordbook_name='wordbook_rdpuapiview_private',
+            is_hidden=True,
+            author=user,
+        )
+
+        wordbook2 = Wordbook(
+            wordbook_name='wordbook_rdpuapiview2_public',
+            is_hidden=False,
+            author=user2,
+        )
+        wordbook2.cards.add(card2)
+        wordbook2.save()
+
+        Wordbook.objects.create(
+            wordbook_name='wordbook_rdpuapiview2_private',
+            is_hidden=True,
+            author=user2,
+        )
+
+    def test_1_success_retrive(self):
+        # 指定した単語帳の詳細情報を取得する事が出来る
+        wordbook = Wordbook.objects.get(wordbook_name='wordbook_rdpuapiview_public')
+        client = APIClient()
+        response = client.get(reverse('api:v1:wordbooks:detail',
+                                      kwargs={'id': wordbook.id}))
+
+        # HTTPレスポンスステータスコードの検証
+        self.assertEqual(response.status_code, 200)
+        # HTTPレスポンスの検証
+        json_response = json_loads(response.content)
+        self.assertEqual(len(json_response.keys()), 5)
+        self.assertEqual(json_response['wordbook_name'], 'wordbook_rdpuapiview_public')
+        self.assertEqual(json_response['author_name'], 'wordbook_rdpuapiview')
+        self.assertFalse(json_response['is_hidden'])
+        self.assertIsNotNone(json_response['id'])
+        self.assertIsNotNone(json_response['create_date'])
+
+    def test_2_fail_retrive_no_exist(self):
+        # 存在しない単語帳の詳細情報を取得しようとすると404が返ってくる
+        client = APIClient()
+        response = client.get(reverse('api:v1:wordbooks:detail',
+                                      kwargs={'id': '00000000-0000-0000-0000-000000000000'}))
+
+        # HTTPレスポンスステータスコードの検証
+        self.assertEqual(response.status_code, 404)
+
+    def test_3_success_retrive_hidden(self):
+        # 非公開単語帳はその作者として認証されている状態でアクセスした場合は取得できる
+        wordbook = Wordbook.objects.get(wordbook_name='wordbook_rdpuapiview_private')
+        user = User.objects.get(username='wordbook_rdpuapiview')
+
+        client = APIClient()
+        client.force_login(user)
+        response = client.get(reverse('api:v1:wordbooks:detail',
+                                      kwargs={'id': wordbook.id}))
+
+        # HTTPレスポンスステータスコードの検証
+        self.assertEqual(response.status_code, 200)
+        # HTTPレスポンスの検証
+        json_response = json_loads(response.content)
+        self.assertEqual(len(json_response.keys()), 5)
+        self.assertEqual(json_response['wordbook_name'], 'wordbook_rdpuapiview_private')
+        self.assertEqual(json_response['author_name'], 'wordbook_rdpuapiview')
+        self.assertTrue(json_response['is_hidden'])
+        self.assertIsNotNone(json_response['id'])
+        self.assertIsNotNone(json_response['create_date'])
+
+    def test_4_fail_retrive_hidden_unauthorization(self):
+        # 非公開単語帳は認証されていない状態でアクセスした場合は取得できない
+        wordbook = Wordbook.objects.get(wordbook_name='wordbook_rdpuapiview_private')
+
+        client = APIClient()
+        response = client.get(reverse('api:v1:wordbooks:detail',
+                                      kwargs={'id': wordbook.id}))
+
+        # HTTPレスポンスステータスコードの検証
+        self.assertEqual(response.status_code, 403)
+
+    def test_5_fail_retrive_hidden_otheruser(self):
+        # 非公開単語帳は作者以外のユーザとして認証されている状態でアクセスした場合は取得できない
+        wordbook = Wordbook.objects.get(wordbook_name='wordbook_rdpuapiview_private')
+        user = User.objects.get(username='wordbook_rdpuapiview2')
+
+        client = APIClient()
+        client.force_login(user)
+        response = client.get(reverse('api:v1:wordbooks:detail',
+                                      kwargs={'id': wordbook.id}))
+
+        # HTTPレスポンスステータスコードの検証
+        self.assertEqual(response.status_code, 403)
+
+    def test_6_success_update(self):
+        # その単語帳のauthorとしてログインしている場合は適切な入力値で単語帳の
+        # wordbook_name, is_hidden, 格納されているカードを更新する事が出来る
+        wordbook = Wordbook.objects.get(wordbook_name='wordbook_rdpuapiview_public')
+        user = User.objects.get(username='wordbook_rdpuapiview')
+
+        card = Card.objects.get(word='wordbook_rdpuapiview')
+        card2 = Card.objects.get(word='wordbook_rdpuapiview2')
+
+        params = {
+            'wordbook_name': 'update_wordbook_rdpuapiview_public',
+            'is_hidden': True,
+            'add_cards': [card2.id],
+            'delete_cards': [card.id],
+        }
+
+        client = APIClient()
+        client.force_login(user)
+        response = client.patch(reverse('api:v1:wordbooks:detail',
+                                        kwargs={'id': wordbook.id}),
+                                params,
+                                format='json')
+        # HTTPレスポンスステータスコードの検証
+        self.assertEqual(response.status_code, 200)
+        # 単語帳が更新されたか検証
+        updated_wordbook = Wordbook.objects.get(id=wordbook.id)
+        self.assertFalse(card in updated_wordbook.cards.all())
+        self.assertTrue(card2 in updated_wordbook.cards.all())
+
+    def test_7_fail_update_unauthorization(self):
+        # 認証されていない場合は適切な入力値でもカードのword,answer,is_hiddenを
+        # 更新する事が出来ない (403が返ってくる)
+        wordbook = Wordbook.objects.get(wordbook_name='wordbook_rdpuapiview_public')
+        user = User.objects.get(username='wordbook_rdpuapiview2')
+
+        card = Card.objects.get(word='wordbook_rdpuapiview')
+        card2 = Card.objects.get(word='wordbook_rdpuapiview2')
+
+        params = {
+            'wordbook_name': 'update_wordbook_rdpuapiview_public',
+            'is_hidden': True,
+            'add_cards': [card2.id],
+            'delete_cards': [card.id],
+        }
+
+        client = APIClient()
+        client.force_login(user)
+        response = client.patch(reverse('api:v1:wordbooks:detail',
+                                        kwargs={'id': wordbook.id}),
+                                params,
+                                format='json')
+        # HTTPレスポンスステータスコードの検証
+        self.assertEqual(response.status_code, 403)
+
+    def test_8_fail_update_other_user(self):
+        # author以外のユーザとして認証されている場合は適切な入力値でも単語帳の情報を
+        # を更新する事が出来ない (403が返ってくる)
+        wordbook = Wordbook.objects.get(wordbook_name='wordbook_rdpuapiview_public')
+
+        card = Card.objects.get(word='wordbook_rdpuapiview')
+        card2 = Card.objects.get(word='wordbook_rdpuapiview2')
+
+        params = {
+            'wordbook_name': 'update_wordbook_rdpuapiview_public',
+            'is_hidden': True,
+            'add_cards': [card2.id],
+            'delete_cards': [card.id],
+        }
+
+        client = APIClient()
+        response = client.patch(reverse('api:v1:wordbooks:detail',
+                                        kwargs={'id': wordbook.id}),
+                                params,
+                                format='json')
+        # HTTPレスポンスステータスコードの検証
+        self.assertEqual(response.status_code, 403)
+
+    def test_9_fail_update_wrong_params(self):
+        # その単語帳のauthorとしてログインしている場合でも不適切な入力値では
+        # 単語帳のwordとanswerを更新する事が出来ない (400が返ってくる)
+        wordbook = Wordbook.objects.get(wordbook_name='wordbook_rdpuapiview_public')
+        user = User.objects.get(username='wordbook_rdpuapiview')
+
+        card = Card.objects.get(word='wordbook_rdpuapiview')
+        card2 = Card.objects.get(word='wordbook_rdpuapiview2')
+
+        wrong_params_list = [
+            {
+                'wordbook_name': 'A' * 101,
+                'is_hidden': True,
+                'add_cards': [card2.id],
+                'delete_cards': [card.id],
+            },
+            {
+                'wordbook_name': 'update_wordbook_rdpuapiview_public',
+                'is_hidden': 'wrong_param',
+                'add_cards': [card2.id],
+                'delete_cards': [card.id],
+            },
+            {
+                'wordbook_name': 'update_wordbook_rdpuapiview_public',
+                'is_hidden': True,
+                'add_cards': ['wrong_param'],
+                'delete_cards': [card.id],
+            },
+            {
+                'wordbook_name': 'update_wordbook_rdpuapiview_public',
+                'is_hidden': True,
+                'add_cards': [card2.id],
+                'delete_cards': ['wrong_param'],
+            }
+        ]
+
+        client = APIClient()
+        client.force_login(user)
+
+        for wrong_param in wrong_params_list:
+            response = client.patch(reverse('api:v1:wordbooks:detail',
+                                            kwargs={'id': wordbook.id}),
+                                    wrong_param,
+                                    format='json')
+            # HTTPレスポンスステータスコードの検証
+            self.assertEqual(response.status_code, 400)
+
+    def test_10_success_delete(self):
+        # その単語帳のauthorとしてログインしている場合はその単語帳を削除できる
+        # (204が返ってくる)
+        wordbook = Wordbook.objects.get(wordbook_name='wordbook_rdpuapiview_public')
+        user = User.objects.get(username='wordbook_rdpuapiview')
+
+        client = APIClient()
+        client.force_login(user)
+        response = client.delete(reverse('api:v1:wordbooks:detail',
+                                         kwargs={'id': wordbook.id}))
+        # HTTPレスポンスステータスコードの検証
+        self.assertEqual(response.status_code, 204)
+        # 単語帳が削除されたか検証
+        with self.assertRaises(ObjectDoesNotExist):
+            wordbook = Wordbook.objects.get(wordbook_name='wordbook_rdpuapiview_public')
+
+    def test_11_fail_update_unauthorization(self):
+        # 認証されていない場合はその単語帳を削除する事は出来ない
+        wordbook = Wordbook.objects.get(wordbook_name='wordbook_rdpuapiview_public')
+
+        client = APIClient()
+        response = client.delete(reverse('api:v1:wordbooks:detail',
+                                         kwargs={'id': wordbook.id}))
+        # HTTPレスポンスステータスコードの検証
+        self.assertEqual(response.status_code, 403)
+
+    def test_12_fail_update_other_user(self):
+        # author以外のユーザとして認証されている場合はその単語帳を削除する事は出来ない
+        wordbook = Wordbook.objects.get(wordbook_name='wordbook_rdpuapiview_public')
+        user = User.objects.get(username='wordbook_rdpuapiview2')
+
+        client = APIClient()
+        client.force_login(user)
+        response = client.delete(reverse('api:v1:wordbooks:detail',
+                                         kwargs={'id': wordbook.id}))
+        # HTTPレスポンスステータスコードの検証
+        self.assertEqual(response.status_code, 403)

--- a/api/v1/wordbooks/tests/test_wordbook_retrieveserializer.py
+++ b/api/v1/wordbooks/tests/test_wordbook_retrieveserializer.py
@@ -1,0 +1,45 @@
+from django.contrib.auth import get_user_model
+from rest_framework.test import APITestCase
+
+from ..models import Wordbook
+from ...cards.models import Card
+from ..serializers import WordbookRetrieveSerializer
+
+User = get_user_model()
+
+
+class WordbookRetrieveTest(APITestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        user = User.objects.create(
+            username='wordbook_serializer',
+            email='wordbook_serializer@test.com',
+            password='testpassw0rd123',
+        )
+        user.save()
+
+        wordbook = Wordbook(
+            wordbook_name='wordbook_serializer',
+            author=user
+        )
+        wordbook.save()
+
+        for i in range(1, 6):
+            card = Card(
+                word='wordbook_serializer_{}'.format(i),
+                answer='wordbook_serializer_{}'.format(i),
+                author=user
+            )
+            card.save()
+            wordbook.cards.add(card)
+
+    def test_1_success_retrieve(self):
+        # シリアライザを介してシリアライズされた指定した単語帳のデータを取得する事が出来る
+        wordbook = Wordbook.objects.get(wordbook_name='wordbook_serializer')
+        serializer = WordbookRetrieveSerializer(instance=wordbook)
+        # 取得したデータの内容を比較する (項目)
+        expected_fields = ['id', 'wordbook_name', 'create_date', 'is_hidden',
+                           'author_name']
+        for expected_field, serializer_field in zip(expected_fields, serializer.data.keys()):
+            self.assertEqual(expected_field, serializer_field)

--- a/api/v1/wordbooks/tests/test_wordbook_updateserializer.py
+++ b/api/v1/wordbooks/tests/test_wordbook_updateserializer.py
@@ -1,0 +1,136 @@
+from django.contrib.auth import get_user_model
+from rest_framework.test import APITestCase
+
+from ..models import Wordbook
+from ...cards.models import Card
+from ..serializers import WordbookUpdateSerializer
+
+User = get_user_model()
+
+
+class WordbookSerializerTest(APITestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        user = User.objects.create(
+            username='wordbook_serializer',
+            email='wordbook_serializer@test.com',
+            password='testpassw0rd123',
+        )
+        user.save()
+
+        for i in range(1, 6):
+            Card.objects.create(
+                word='wordbook_serializer_{}'.format(i),
+                answer='wordbook_serializer_{}'.format(i),
+                author=user
+            )
+
+        Wordbook.objects.create(
+            wordbook_name='wordbook_serializer',
+            author=user
+        )
+
+    def test_1_valid_and_success_add_cards(self):
+        # 適切な入力値は妥当であり,単語帳にカードを追加する事が出来る
+        card = Card.objects.get(word='wordbook_serializer_1')
+        card2 = Card.objects.get(word='wordbook_serializer_2')
+
+        params = {
+            'wordbook_name': 'updated_wordbook_serializer',
+            'is_hidden': True,
+            'add_cards': [
+                card.id,
+                card2.id,
+            ],
+            'delete_cards': [
+            ]
+        }
+
+        wordbook = Wordbook.objects.get(wordbook_name='wordbook_serializer')
+        # バリデーション結果の検証
+        serializer = WordbookUpdateSerializer(instance=wordbook, data=params)
+        self.assertTrue(serializer.is_valid())
+        # 単語帳にカードが追加されたか検証
+        serializer.save()
+        added_wordbook = Wordbook.objects.get(wordbook_name='updated_wordbook_serializer')
+        self.assertEqual(len(added_wordbook.cards.all()), 2)
+
+    def test_2_valid_and_success_delete_cards(self):
+        # 適切な入力値は妥当であり,単語帳からカードを削除する事が出来る
+        card = Card.objects.get(word='wordbook_serializer_1')
+        card2 = Card.objects.get(word='wordbook_serializer_2')
+
+        wordbook = Wordbook.objects.get(wordbook_name='wordbook_serializer')
+        wordbook.cards.add(card)
+        wordbook.cards.add(card2)
+
+        params = {
+            'wordbook_name': 'updated_wordbook_serializer',
+            'is_hidden': True,
+            'add_cards': [
+            ],
+            'delete_cards': [
+                card.id,
+                card2.id,
+            ]
+        }
+
+        # バリデーション結果の検証
+        serializer = WordbookUpdateSerializer(instance=wordbook, data=params)
+        self.assertTrue(serializer.is_valid())
+        # 単語帳からカードが削除されたか検証
+        serializer.save()
+        added_wordbook = Wordbook.objects.get(wordbook_name='updated_wordbook_serializer')
+        self.assertEqual(len(added_wordbook.cards.all()), 0)
+
+    def test_3_invalid(self):
+        # 誤った形式の値は妥当ではない
+        card = Card.objects.get(word='wordbook_serializer_1')
+        wordbook = Wordbook.objects.get(wordbook_name='wordbook_serializer')
+
+        wrong_params_list = [
+            {
+                'wordbook_name': 'A' * 101,
+                'is_hidden': True,
+                'add_cards': [
+                    card.id
+                ],
+                'delete_cards': [
+                ]
+            },
+            {
+                'wordbook_name': 'updated_wordbook_serializer',
+                'is_hidden': True,
+                'add_cards': [
+                    'wrong_param'
+                ],
+                'delete_cards': [
+                    card.id
+                ]
+            },
+            {
+                'wordbook_name': 'updated_wordbook_serializer',
+                'is_hidden': True,
+                'add_cards': [
+                    card.id
+                ],
+                'delete_cards': [
+                    'wrong_param'
+                ],
+            },
+            {
+                'wordbook_name': 'updated_wordbook_serializer',
+                'is_hidden': 'wrong_params',
+                'add_cards': [
+                    card.id
+                ],
+                'delete_cards': [
+                ],
+            },
+        ]
+
+        # バリデーション結果の検証
+        for wrong_params in wrong_params_list:
+            serializer = WordbookUpdateSerializer(instance=wordbook, data=wrong_params)
+            self.assertFalse(serializer.is_valid())

--- a/api/v1/wordbooks/urls.py
+++ b/api/v1/wordbooks/urls.py
@@ -1,9 +1,11 @@
 from django.urls import path
 
-from .views import WordbookListCreateAPIView
+from .views import WordbookListCreateAPIView, WordbookRetrieveDeletePartialUpdateAPIView
 
 app_name = 'wordbooks'
 
 urlpatterns = [
     path('', WordbookListCreateAPIView.as_view(), name='list'),
+    path('<uuid:id>/', WordbookRetrieveDeletePartialUpdateAPIView.as_view(),
+         name='detail'),
 ]

--- a/api/v1/wordbooks/views.py
+++ b/api/v1/wordbooks/views.py
@@ -1,9 +1,13 @@
 from django_filters import rest_framework as filters
-from rest_framework.generics import ListCreateAPIView
+from django.shortcuts import get_object_or_404
+from rest_framework.generics import GenericAPIView, ListCreateAPIView
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from rest_framework.mixins import RetrieveModelMixin, UpdateModelMixin, DestroyModelMixin
 
 from .models import Wordbook
-from .serializers import WordbookSerializer, WordbookCreateSerializer
+from .serializers import WordbookSerializer, WordbookRetrieveSerializer, \
+    WordbookCreateSerializer, WordbookUpdateSerializer
+from .permissions import IsNotAuthorReadPublicOnly
 
 
 class WordbookListFilter(filters.FilterSet):
@@ -25,3 +29,39 @@ class WordbookListCreateAPIView(ListCreateAPIView):
         if self.request.user.is_authenticated and http_method == 'POST':
             return WordbookCreateSerializer
         return self.serializer_class
+
+
+class RetrieveDeletePartialUpdateAPIView(RetrieveModelMixin,
+                                         UpdateModelMixin,
+                                         DestroyModelMixin,
+                                         GenericAPIView):
+
+    def get(self, request, *args, **kwargs):
+        return self.retrieve(request, *args, **kwargs)
+
+    def patch(self, request, *args, **kwargs):
+        return self.partial_update(request, *args, **kwargs)
+
+    def delete(self, request, *args, **kwargs):
+        return self.destroy(request, *args, **kwargs)
+
+
+class WordbookRetrieveDeletePartialUpdateAPIView(RetrieveDeletePartialUpdateAPIView):
+    queryset = Wordbook.objects.all()
+    serializer_class = WordbookRetrieveSerializer
+    permission_classes = [IsNotAuthorReadPublicOnly]
+    lookup_field = 'id'
+
+    def get_serializer_class(self):
+        http_method = self.request.method
+        if http_method == 'PATCH':
+            return WordbookUpdateSerializer
+        return self.serializer_class
+
+    def get_permissions(self):
+        # パーミッションクラスにアクセスしたURLに含まれる単語帳を渡す
+        lookup_url_kwarg = self.lookup_url_kwarg or self.lookup_field
+        wordbook_id = self.kwargs[lookup_url_kwarg]
+        wordbook = get_object_or_404(Wordbook, id=wordbook_id)
+        return [permission(wordbook=(wordbook))
+                for permission in self.permission_classes]


### PR DESCRIPTION
# 追加点

- カードの詳細取得に利用するWordbookRetrieveSerializerを作成し,ユニットテストで検証した
- カードの部分更新に利用するWordbookUpdateSerializerを作成し,ユニットテストで検証した
- カードの詳細取得,部分更新,削除に利用するWordbookRetrieveDeletePartialUpdateAPIViewを作成し,ユニットテストで検証した