### PR TITLE
add カードの詳細取得時にそのカードの作者名を返すフィールドを追加した

### DIFF
--- a/api/v1/cards/serializers.py
+++ b/api/v1/cards/serializers.py
@@ -25,9 +25,11 @@ class CardSerializer(serializers.ModelSerializer):
 
 
 class CardRetrieveSerializer(serializers.ModelSerializer):
+    author_name = serializers.SerializerMethodField('get_author_name')
+
     class Meta:
         model = Card
-        fields = ['word', 'answer', 'is_hidden', 'id', 'create_date']
+        fields = ['word', 'answer', 'is_hidden', 'id', 'create_date', 'author_name']
         extra_kwargs = {
             'word': {
                 'read_only': True
@@ -43,8 +45,16 @@ class CardRetrieveSerializer(serializers.ModelSerializer):
             },
             'create_date': {
                 'read_only': True
+            },
+            'author_name': {
+                'read_only': True
             }
         }
+
+    def get_author_name(self, card):
+        author_id = card.author.id
+        author = User.objects.get(id=author_id)
+        return author.username
 
 
 class CardUpdateSerializer(serializers.ModelSerializer):

--- a/api/v1/cards/tests/test_card_rdpuapiview.py
+++ b/api/v1/cards/tests/test_card_rdpuapiview.py
@@ -52,9 +52,10 @@ class CardRetrieveDeletePartialUpdateAPIView(APITestCase):
         self.assertEqual(response.status_code, 200)
         # HTTPレスポンスの検証
         json_response = json_loads(response.content)
-        self.assertEqual(len(json_response.keys()), 5)
+        self.assertEqual(len(json_response.keys()), 6)
         self.assertEqual(json_response['word'], 'card_rdpuapiview')
         self.assertEqual(json_response['answer'], 'card_rdpuapiview')
+        self.assertEqual(json_response['author_name'], 'card_rdpuapiview')
         self.assertFalse(json_response['is_hidden'])
         self.assertIsNotNone(json_response['id'])
         self.assertIsNotNone(json_response['create_date'])
@@ -82,9 +83,10 @@ class CardRetrieveDeletePartialUpdateAPIView(APITestCase):
         self.assertEqual(response.status_code, 200)
         # HTTPレスポンスの検証
         json_response = json_loads(response.content)
-        self.assertEqual(len(json_response.keys()), 5)
+        self.assertEqual(len(json_response.keys()), 6)
         self.assertEqual(json_response['word'], 'card_rdpuapiview2')
         self.assertEqual(json_response['answer'], 'card_rdpuapiview2')
+        self.assertEqual(json_response['author_name'], 'card_rdpuapiview2')
         self.assertTrue(json_response['is_hidden'])
         self.assertIsNotNone(json_response['id'])
         self.assertIsNotNone(json_response['create_date'])

--- a/api/v1/cards/tests/test_card_retriveserializer.py
+++ b/api/v1/cards/tests/test_card_retriveserializer.py
@@ -29,6 +29,6 @@ class CardRetrieveSerializerTest(APITestCase):
         card = Card.objects.get(word='card_retrieve_serializer')
         serializer = CardRetrieveSerializer(instance=card)
         # 取得したデータの内容を比較する (項目名によって検査する)
-        expected_fields = ['word', 'answer', 'is_hidden', 'id', 'create_date']
+        expected_fields = ['word', 'answer', 'is_hidden', 'id', 'create_date', 'author_name']
         for expected_field, serializer_field in zip(expected_fields, serializer.data.keys()):
             self.assertEqual(expected_field, serializer_field)

--- a/api/v1/cards/tests/test_card_serializer.py
+++ b/api/v1/cards/tests/test_card_serializer.py
@@ -29,3 +29,7 @@ class CardSerializerTest(APITestCase):
         serializer = CardSerializer(instance=cards, many=True)
         # 予想した件数を取得する事が出来る
         self.assertEqual(len(serializer.data), 5)
+        # 予想したフィールドの値を取得する事が出来る
+        expected_fields = ['id', 'word', 'answer']
+        for expected_field, serializer_field in zip(expected_fields, serializer.data[0].keys()):
+            self.assertEqual(expected_field, serializer_field)


### PR DESCRIPTION
# 追加点

- CardRetrieveSerializerにauthor_nameというSerializerMethodFieldを追加した
- 上記の変更に基づき,ユニットテストの変更・追加を行った
