### PR TITLE
fix /wordbooks/において一覧取得時と新規作成において微修正

### DIFF
--- a/api/v1/wordbooks/serializers.py
+++ b/api/v1/wordbooks/serializers.py
@@ -103,9 +103,6 @@ class WordbookCreateSerializer(serializers.ModelSerializer):
         model = Wordbook
         fields = ['wordbook_name', 'is_hidden', 'id', 'create_date']
         extra_kwargs = {
-            'is_hidden': {
-                'write_only': True
-            },
             'id': {
                 'read_only': True
             },


### PR DESCRIPTION
# 修正点

- 一覧取得時: アクセスユーザが認証されている場合はそのユーザが作成した非公開の単語帳をリストに含める様に変更
- 新規作成時: 作成した後にis_hiddenフィールドが表示される様に統一