### PR TITLE
Fix /users/と/users/<str:username>における修正

### DIFF
--- a/api/v1/users/tests/test_user_listapiview.py
+++ b/api/v1/users/tests/test_user_listapiview.py
@@ -20,7 +20,17 @@ class UserListAPIViewTest(APITestCase):
                                      email='user_listapiview_B{}@test.com'.format(i),
                                      password='testpassw0rd123')
 
-    def test_success_access_and_get_users(self):
+        User.objects.create_user(username='user_listapiview_super',
+                                 email='user_listapiview_super@test.com',
+                                 is_superuser=True,
+                                 password='testpassw0rd123')
+
+        User.objects.create_user(username='user_listapiview_staff',
+                                 email='user_listapiview_staff@test.com',
+                                 is_staff=True,
+                                 password='testpassw0rd123')
+
+    def test_1_success_access_and_get_users(self):
         # APIViewに対してアクセスする事と10件の情報を取得する事が出来る
         client = APIClient()
         response = client.get(reverse('api:v1:users:list'))
@@ -30,8 +40,9 @@ class UserListAPIViewTest(APITestCase):
         # JSONレスポンスの確認 (取得件数を表すcountの値の比較によって確認を行う)
         response_json = json_loads(response.content.decode('utf-8'))
         self.assertEqual(response_json['count'], 22)
+        self.assertEqual(len(response_json['results']), 10)
 
-    def test_success_access_max_page(self):
+    def test_2_success_access_max_page(self):
         # ページネーションが正常に機能し,最後のページの場合next=nullとなっている
         client = APIClient()
         response = client.get(''.join([reverse('api:v1:users:list'),
@@ -44,7 +55,7 @@ class UserListAPIViewTest(APITestCase):
         response_json = json_loads(response.content.decode('utf-8'))
         self.assertIsNone(response_json['next'])
 
-    def test_success_get_only_satisfy_requirment(self):
+    def test_3_success_get_only_satisfy_requirment(self):
         # qパラメータで指定した条件に合致する情報のみ取得する事可能で,
         # ページネーションも正常に機能している
         client = APIClient()
@@ -58,7 +69,7 @@ class UserListAPIViewTest(APITestCase):
         response_json = json_loads(response.content.decode('utf-8'))
         self.assertEqual(response_json['count'], 11)
 
-    def test_fail_access_over_page(self):
+    def test_4_fail_access_over_page(self):
         # ページネーションが正常に機能し,存在しないページにアクセスすると404が返ってくる
         client = APIClient()
         response = client.get(''.join([reverse('api:v1:users:list'),
@@ -71,7 +82,7 @@ class UserListAPIViewTest(APITestCase):
         expected_json = {'detail': '不正なページです。'}
         self.assertJSONEqual(response.content, expected_json)
 
-    def test_fail_get_no_satisfy_requirment(self):
+    def test_5_fail_get_no_satisfy_requirment(self):
         # 条件に合致するデータが無い時,何も取得できない
         client = APIClient()
         response = client.get(''.join([reverse('api:v1:users:list'),

--- a/api/v1/users/views.py
+++ b/api/v1/users/views.py
@@ -2,8 +2,8 @@ from django.contrib.auth import get_user_model
 from django.db.models.query import QuerySet
 from django_filters import rest_framework as filters
 from django.shortcuts import get_object_or_404
-from rest_framework.mixins import UpdateModelMixin
-from rest_framework.generics import GenericAPIView, ListAPIView, RetrieveUpdateDestroyAPIView
+from rest_framework.mixins import RetrieveModelMixin, UpdateModelMixin, DestroyModelMixin
+from rest_framework.generics import GenericAPIView, ListAPIView
 from rest_framework.permissions import AllowAny, IsAuthenticated
 
 from .permissions import IsSelfOrReadOnly
@@ -31,12 +31,27 @@ class UserListAPIView(ListAPIView):
     filter_class = UserListFilter
 
 
-class UserRetrieveUpdateDestroyAPIView(RetrieveUpdateDestroyAPIView):
+class RetrieveDeletePartialUpdateAPIView(RetrieveModelMixin,
+                                         UpdateModelMixin,
+                                         DestroyModelMixin,
+                                         GenericAPIView):
+
+    def get(self, request, *args, **kwargs):
+        return self.retrieve(request, *args, **kwargs)
+
+    def patch(self, request, *args, **kwargs):
+        return self.partial_update(request, *args, **kwargs)
+
+    def delete(self, request, *args, **kwargs):
+        return self.destroy(request, *args, **kwargs)
+
+
+class UserRetrieveUpdateDestroyAPIView(RetrieveDeletePartialUpdateAPIView):
     """
     指定したユーザの詳細情報の取得,情報の更新,削除を行うAPIView
     """
     lookup_field = 'username'
-    queryset = User.objects.all().order_by('date_joined')
+    queryset = User.objects.filter(is_superuser=False, is_staff=False).all().order_by('date_joined')
     serializer_class = UserSerializer
     permission_classes = [IsSelfOrReadOnly]
 

--- a/api/v1/users/views.py
+++ b/api/v1/users/views.py
@@ -25,7 +25,7 @@ class UserListFilter(filters.FilterSet):
 
 
 class UserListAPIView(ListAPIView):
-    queryset = User.objects.all().order_by('date_joined')
+    queryset = User.objects.filter(is_superuser=False, is_staff=False).all().order_by('date_joined')
     serializer_class = UserSerializer
     permission_classes = [AllowAny]
     filter_class = UserListFilter


### PR DESCRIPTION
# 修正点

## /users/

- 一覧取得時にstaff権限または管理者権限が有効なユーザは表示しない様に修正した

## /users/<str:username>

- staff権限または管理者権限が有効なユーザは詳細取得・部分更新・削除させない様に修正した
