### PR TITLE
add 404に対応したWebページの追加と,それに伴うクライアントサイドの変更

### DIFF
--- a/error_front/urls.py
+++ b/error_front/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
 
-from .views import ForbiddenView
+from .views import ForbiddenView, NotFoundView
 
 app_name = 'error_front'
 
 urlpatterns = [
     path('403/', ForbiddenView.as_view(), name='403'),
+    path('404/', NotFoundView.as_view(), name='404'),
 ]

--- a/error_front/views.py
+++ b/error_front/views.py
@@ -3,3 +3,7 @@ from django.views.generic import TemplateView
 
 class ForbiddenView(TemplateView):
     template_name = 'error_front/403.html'
+
+
+class NotFoundView(TemplateView):
+    template_name = 'error_front/404.html'

--- a/static/cards_front/card.js
+++ b/static/cards_front/card.js
@@ -26,13 +26,17 @@ const app = new Vue({
             }
         })
         .catch(error => {
-            // ステータスコードが2XXでなかった場合はalertでエラー内容を表示
-            if (error.response.status == 403) {
-                window.location.href = '/error/403/';
-            }
-            else
-            {
-                window.alert('カード情報が取得できませんでした。');
+            // ステータスコードが2XXでなかった場合はalertでリダイレクトまたはエラー内容を表示
+            switch (error.response.status) {
+                case 403:
+                    window.location.href = '/error/403/';
+                    break;
+                case 404:
+                    window.location.href = '/error/404/';
+                    break;
+                default:
+                    window.alert('カード情報が取得できませんでした。');
+                    break;
             }
         })
     },

--- a/static/wordbooks_front/wordbook.js
+++ b/static/wordbooks_front/wordbook.js
@@ -34,13 +34,17 @@ const app = new Vue({
                 }
             })
             .catch(error => {
-                // ステータスコードが2XXでなかった場合はalertでエラー内容を表示
-                if (error.response.status == 403) {
-                    window.location.href = '/error/403/';
-                }
-                else
-                {
-                    window.alert('単語帳情報の取得に失敗しました。');
+                // ステータスコードが2XXでなかった場合はalertでリダイレクトまたはエラー内容を表示
+                switch (error.response.status) {
+                    case 403:
+                        window.location.href = '/error/403/';
+                        break;
+                    case 404:
+                        window.location.href = '/error/404/';
+                        break;
+                    default:
+                        window.alert('単語帳情報の取得に失敗しました。');
+                        break;
                 }
             })
         },
@@ -67,13 +71,17 @@ const app = new Vue({
                 }
             })
             .catch(error => {
-                // ステータスコードが2XXでなかった場合はalertでエラー内容を表示
-                if (error.response.status == 403) {
-                    window.location.href = '/error/403/';
-                }
-                else
-                {
-                    window.alert('カード情報の取得に失敗しました。');
+                // ステータスコードが2XXでなかった場合はalertでリダイレクトまたはエラー内容を表示
+                switch (error.response.status) {
+                    case 403:
+                        window.location.href = '/error/403/';
+                        break;
+                    case 404:
+                        window.location.href = '/error/404/';
+                        break;
+                    default:
+                        window.alert('カード情報の取得に失敗しました。');
+                        break;
                 }
             })
         },

--- a/templates/error_front/404.html
+++ b/templates/error_front/404.html
@@ -1,0 +1,17 @@
+{% extends 'base/base.html' %}
+{% load static %}
+
+{% block extra_header %}
+    <link rel="stylesheet" href="{% static 'error_front/error_page.css' %}">
+{% endblock %}
+
+{% block content %}
+    <div id="main">
+        <div id="status-code">
+            404 (Not Found)
+        </div>
+        <div id="error-message">
+            指定されたリソースは存在しません。
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
# 追加点

- 403に対応したWebページを構築するNotFoundView, 404.htmlを追加した
- card.js,wordbook.jsにおいて404が返ってきたら/error/404/にリダイレクトする様に変更