### PR TITLE
add ユーザが作成したカードの一覧・検索機能のページにカードの削除機能を追加した

### DIFF
--- a/static/settings_front/cards.css
+++ b/static/settings_front/cards.css
@@ -23,3 +23,18 @@
 #card-list .edit-button {
     margin: 30px 0px 0px 5px;
 }
+
+#card-list .edit-button a {
+    color: gray;
+    text-decoration: none;
+}
+
+#card-list .edit-button a:hover {
+    color: gray;
+    text-decoration: none;
+}
+
+#card-list .delete-button {
+    color: gray;
+    margin: 30px 0px 0px 5px;
+}

--- a/static/settings_front/cards.js
+++ b/static/settings_front/cards.js
@@ -52,6 +52,30 @@ const app = new Vue({
         get_edit_card_page_url: function(card_id) {
             // カードの編集ページへのリンクを作成
             return `/settings/cards/${card_id}/`;
+        },
+        delete_card: function(card_id, card_index) {
+            // 削除するか確認
+            let partial_card_word = this.cards_per_page[card_index].word.substring(0, 10);
+            if (this.cards_per_page[card_index].word.substring(0, 10).length > 10) {
+                partial_card_word += '...';
+            }
+            window.confirm(`${partial_card_word}を削除しますか?`);
+            // csrftokenを取得
+            const csrftoken = $cookies.get('csrftoken');
+            const headers = {'X-CSRFToken': csrftoken};
+            // 指定したカードを削除
+            axios.delete(
+                `/api/v1/cards/${card_id}/`, {headers: headers}
+            )
+            .then(response => {
+                // カードの削除に成功した事を表示して,ページを再読み込み
+                window.alert('カードの削除に成功しました。');
+                location.reload();
+            })
+            .catch(error => {
+                // ステータスコードが2XXでなかった場合はalertでエラー内容を表示
+                window.alert('カード情報の取得に失敗しました。');
+            })
         }
     },
     computed: {

--- a/templates/settings_front/cards.html
+++ b/templates/settings_front/cards.html
@@ -33,6 +33,7 @@
             </div>
             
             <div id="card-list">
+                {% csrf_token %}
                 <ul>
                     <li class="card-and-button" v-for="(card, index) in cards_per_page" v-bind:key="index">
                         <div class="card">
@@ -58,6 +59,10 @@
                             <a v-bind:href="get_edit_card_page_url(card.id)">
                                 <i class="fas fa-edit"></i>
                             </a>
+                        </div>
+
+                        <div class="delete-button" v-bind:key="index">
+                            <i class="fas fa-trash" v-on:click.prevent="delete_card(card.id, index)"></i>
                         </div>
                     </li>
                 </ul>


### PR DESCRIPTION
# 追加点

- settings_front/cards.htmlに削除ボタンを追加
- settings_front/cards.jsに削除ボタンがクリックされた時に実行するdelete_card()を追加
- settings_front/cards.cssに削除ボタンのデザインを追加