### PR TITLE
add CardListFilterにexclude_wordbook_idパラメータを追加

### DIFF
--- a/api/v1/cards/views.py
+++ b/api/v1/cards/views.py
@@ -13,10 +13,13 @@ from .permissions import IsNotAuthorReadPublicOnly
 
 class CardListFilter(filters.FilterSet):
     q = filters.CharFilter(field_name='word', lookup_expr='contains')
+    exclude_wordbook_id = filters.BaseInFilter(field_name='wordbooks',
+                                               exclude=True,
+                                               lookup_expr='in')
 
     class Meta:
         model = Card
-        fields = ['word']
+        fields = ['word', 'wordbooks']
 
 
 class CardListCreateAPIView(ListCreateAPIView):


### PR DESCRIPTION
# 追加点

- CardListFilterにexclude_wordbook_idパラメータを追加
- exclude_wordbook_idには単語帳のIDを指定し,指定した単語帳に含まれるカードをカード一覧から除外する
- exlucde_wordbook_idを利用してカードを適切に取得する事ができるか検証するためのユニットテストを追加した