### PR TITLE
fix 非公開カードの作者でないユーザがそのカードを単語帳に追加出来ない様に修正した

### DIFF
--- a/api/v1/wordbooks/tests/test_wordbook_updateserializer.py
+++ b/api/v1/wordbooks/tests/test_wordbook_updateserializer.py
@@ -1,3 +1,4 @@
+from functools import partial
 from django.contrib.auth import get_user_model
 from rest_framework.test import APITestCase
 
@@ -19,12 +20,26 @@ class WordbookSerializerTest(APITestCase):
         )
         user.save()
 
+        user2 = User.objects.create(
+            username='wordbook_serializer2',
+            email='wordbook_serializer2@test.com',
+            password='testpassw0rd123',
+        )
+        user2.save()
+
         for i in range(1, 6):
             Card.objects.create(
                 word='wordbook_serializer_{}'.format(i),
                 answer='wordbook_serializer_{}'.format(i),
                 author=user
             )
+
+        Card.objects.create(
+            word='wordbook_serializer_hidden',
+            answer='wordbook_serializer_hidden',
+            is_hidden=True,
+            author=user2
+        )
 
         Wordbook.objects.create(
             wordbook_name='wordbook_serializer',
@@ -35,6 +50,7 @@ class WordbookSerializerTest(APITestCase):
         # 適切な入力値は妥当であり,単語帳にカードを追加する事が出来る
         card = Card.objects.get(word='wordbook_serializer_1')
         card2 = Card.objects.get(word='wordbook_serializer_2')
+        hidden_card = Card.objects.get(word='wordbook_serializer_hidden')
 
         params = {
             'wordbook_name': 'updated_wordbook_serializer',
@@ -42,6 +58,7 @@ class WordbookSerializerTest(APITestCase):
             'add_cards': [
                 card.id,
                 card2.id,
+                hidden_card.id,
             ],
             'delete_cards': [
             ]
@@ -49,21 +66,53 @@ class WordbookSerializerTest(APITestCase):
 
         wordbook = Wordbook.objects.get(wordbook_name='wordbook_serializer')
         # バリデーション結果の検証
-        serializer = WordbookUpdateSerializer(instance=wordbook, data=params)
+        serializer = WordbookUpdateSerializer(instance=wordbook,
+                                              data=params,
+                                              partial=True)
         self.assertTrue(serializer.is_valid())
         # 単語帳にカードが追加されたか検証
         serializer.save()
         added_wordbook = Wordbook.objects.get(wordbook_name='updated_wordbook_serializer')
         self.assertEqual(len(added_wordbook.cards.all()), 2)
+        # 他のユーザが作成した非公開カードのIDを追加する事は出来ない
+        self.assertFalse(hidden_card in added_wordbook.cards.all())
 
-    def test_2_valid_and_success_delete_cards(self):
+    def test_2_valid_and_success_add_cards_with_userinfo(self):
+        # 適切な入力値は妥当であり,単語帳にカードを追加する事が出来る
+        # また,非公開カードであってもuserに作者の情報を渡している場合は追加する事が出来る
+        card = Card.objects.get(word='wordbook_serializer_1')
+        card2 = Card.objects.get(word='wordbook_serializer_2')
+        hidden_card = Card.objects.get(word='wordbook_serializer_hidden')
+
+        params = {
+            'wordbook_name': 'updated_wordbook_serializer',
+            'is_hidden': True,
+            'add_cards': [
+                card.id,
+                card2.id,
+                hidden_card.id,
+            ],
+            'delete_cards': [
+            ]
+        }
+
+        wordbook = Wordbook.objects.get(wordbook_name='wordbook_serializer')
+        # バリデーション結果の検証
+        user = User.objects.get(username='wordbook_serializer2')
+        serializer = WordbookUpdateSerializer(instance=wordbook,
+                                              data=params,
+                                              partial=True,
+                                              user=user)
+        self.assertTrue(serializer.is_valid())
+        # 単語帳にカードが追加されたか検証
+        serializer.save()
+        added_wordbook = Wordbook.objects.get(wordbook_name='updated_wordbook_serializer')
+        self.assertEqual(len(added_wordbook.cards.all()), 3)
+
+    def test_3_valid_and_success_delete_cards(self):
         # 適切な入力値は妥当であり,単語帳からカードを削除する事が出来る
         card = Card.objects.get(word='wordbook_serializer_1')
         card2 = Card.objects.get(word='wordbook_serializer_2')
-
-        wordbook = Wordbook.objects.get(wordbook_name='wordbook_serializer')
-        wordbook.cards.add(card)
-        wordbook.cards.add(card2)
 
         params = {
             'wordbook_name': 'updated_wordbook_serializer',
@@ -77,14 +126,17 @@ class WordbookSerializerTest(APITestCase):
         }
 
         # バリデーション結果の検証
-        serializer = WordbookUpdateSerializer(instance=wordbook, data=params)
+        wordbook = Wordbook.objects.get(wordbook_name='wordbook_serializer')
+        serializer = WordbookUpdateSerializer(instance=wordbook,
+                                              data=params,
+                                              partial=True)
         self.assertTrue(serializer.is_valid())
         # 単語帳からカードが削除されたか検証
         serializer.save()
         added_wordbook = Wordbook.objects.get(wordbook_name='updated_wordbook_serializer')
         self.assertEqual(len(added_wordbook.cards.all()), 0)
 
-    def test_3_invalid(self):
+    def test_4_invalid(self):
         # 誤った形式の値は妥当ではない
         card = Card.objects.get(word='wordbook_serializer_1')
         wordbook = Wordbook.objects.get(wordbook_name='wordbook_serializer')
@@ -132,5 +184,7 @@ class WordbookSerializerTest(APITestCase):
 
         # バリデーション結果の検証
         for wrong_params in wrong_params_list:
-            serializer = WordbookUpdateSerializer(instance=wordbook, data=wrong_params)
+            serializer = WordbookUpdateSerializer(instance=wordbook,
+                                                  data=wrong_params,
+                                                  partial=True)
             self.assertFalse(serializer.is_valid())

--- a/api/v1/wordbooks/tests/test_wordbook_updateserializer.py
+++ b/api/v1/wordbooks/tests/test_wordbook_updateserializer.py
@@ -1,4 +1,3 @@
-from functools import partial
 from django.contrib.auth import get_user_model
 from rest_framework.test import APITestCase
 

--- a/api/v1/wordbooks/views.py
+++ b/api/v1/wordbooks/views.py
@@ -73,6 +73,14 @@ class WordbookRetrieveDeletePartialUpdateAPIView(RetrieveDeletePartialUpdateAPIV
     permission_classes = [IsNotAuthorReadPublicOnly]
     lookup_field = 'id'
 
+    def get_serializer(self, *args, **kwargs):
+        serializer_class = self.get_serializer_class()
+        kwargs.setdefault('context', self.get_serializer_context())
+        http_method = self.request.method
+        if http_method == 'PATCH':
+            kwargs.update({'user': self.request.user})
+        return serializer_class(*args, **kwargs)
+
     def get_serializer_class(self):
         http_method = self.request.method
         if http_method == 'PATCH':


### PR DESCRIPTION
# 修正点

- 非公開カードのUUIDが漏洩・総当たりされた場合でも、そのカードの作者でない場合は単語帳にカードを追加出来ない様に修正した
- また、上記の修正に伴いユニットテストの修正と検証を行い、動作を確認した
