### PR TITLE
fix /settings/wordbooks/において自分が作成していない単語帳を編集しようとした場合,403ページへリダイレクトする様に変更

### DIFF
--- a/static/settings_front/wordbook_add_cards.js
+++ b/static/settings_front/wordbook_add_cards.js
@@ -28,6 +28,10 @@ const app = new Vue({
         )
         .then(response => {
             if (response.status == 200){
+                // 作者でないのに単語帳へカードを追加しようとした場合は403へリダイレクト
+                if (this.username != response.data.author_name) {
+                    window.location.href = '/error/403/';
+                }
                 this.wordbook_name = response.data.wordbook_name;
                 this.is_hidden = response.data.is_hidden;
             }

--- a/static/settings_front/wordbook_delete_cards.js
+++ b/static/settings_front/wordbook_delete_cards.js
@@ -25,6 +25,10 @@ const app = new Vue({
         )
         .then(response => {
             if (response.status == 200){
+                // 作者でないのに単語帳へカードを削除しようとした場合は403へリダイレクト
+                if (this.username != response.data.author_name) {
+                    window.location.href = '/error/403/';
+                }
                 this.wordbook_name = response.data.wordbook_name;
                 this.is_hidden = response.data.is_hidden;
             }


### PR DESCRIPTION
# 修正点

- 実際にカードの追加・削除を行う事は出来ないが,カードの追加・削除ページへアクセス出来る事はおかしいので修正